### PR TITLE
Add note about assets to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ CREW Utilities
 Miscellaneous helpers for CREW that do not have any clearer home.
 
 Going forward, CREW-related code should live in https://github.com/climatecrew.
+
+# Assets
+
+Original versions of the CREW logo live in the assets/crew-logos directory.


### PR DESCRIPTION
This is a test of requesting a reviewer before clicking the 'Create pull request' button.

Result: Github sends a separate `review_requested` action webhook even though the reviewer was chosen before creating the PR. That payload has a populated  `requested_reviewers` list.

The initial `opened` action webhook comes with an empty list for `requested_reviewers`.